### PR TITLE
Add docs for deploy -c option

### DIFF
--- a/docs/providers/aws/cli-reference/deploy.md
+++ b/docs/providers/aws/cli-reference/deploy.md
@@ -19,6 +19,7 @@ serverless deploy
 ```
 
 ## Options
+- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--package` or `-p` path to a pre-packaged directory and skip packaging step.

--- a/docs/providers/aws/guide/deploying.md
+++ b/docs/providers/aws/guide/deploying.md
@@ -24,7 +24,7 @@ serverless deploy
 
 Use this method when you have updated your Function, Event or Resource configuration in `serverless.yml` and you want to deploy that change (or multiple changes at the same time) to Amazon Web Services.
 
-**Note:** You can always enforce a deployment using the `--force` option.
+**Note:** You can always enforce a deployment using the `--force` option, or specify a different configuration file name with the the `--config` option. 
 
 ### How It Works
 

--- a/docs/providers/aws/guide/intro.md
+++ b/docs/providers/aws/guide/intro.md
@@ -58,7 +58,7 @@ The Serverless Framework not only deploys your Functions and the Events that tri
 
 ### Services
 
-A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
+A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file by default entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
 
 ```yml
 # serverless.yml
@@ -75,7 +75,7 @@ functions: # Your "Functions"
 
 resources: # The "Resources" your "Functions" use.  Raw AWS CloudFormation goes in here.
 ```
-When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` is deployed at once.
+When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` (or the file specified with the `--config` option) is deployed at once.
 
 ### Plugins
 

--- a/docs/providers/azure/cli-reference/deploy.md
+++ b/docs/providers/azure/cli-reference/deploy.md
@@ -23,6 +23,7 @@ serverless deploy
 ```
 
 ## Options
+- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut.

--- a/docs/providers/azure/guide/deploying.md
+++ b/docs/providers/azure/guide/deploying.md
@@ -28,6 +28,8 @@ Use this method when you have updated your Function, Event or Resource
 configuration in `serverless.yml` and you want to deploy that change (or multiple
 changes at the same time) to Azure Functions.
 
+**Note:** You can specify a different configuration file name with the the `--config` option. 
+
 ### How It Works
 
 The Serverless Framework translates all syntax in `serverless.yml` to an Azure

--- a/docs/providers/azure/guide/intro.md
+++ b/docs/providers/azure/guide/intro.md
@@ -63,7 +63,7 @@ needed for that event and configure your functions to listen to it.
 A **Service** is the Framework's unit of organization. You can think of it as a
 project file, though you can have multiple services for a single application.
 It's where you define your Functions, the Events that trigger them, and the
-Resources your Functions use, all in one file entitled `serverless.yml` (or
+Resources your Functions use, all in one file by default entitled `serverless.yml` (or
 `serverless.json` or `serverless.js`). It looks like this:
 
 ```yml
@@ -91,7 +91,7 @@ functions: # Your "Functions"
 ```
 
 When you deploy with the Framework by running `serverless deploy`, everything in
-`serverless.yml` is deployed at once.
+`serverless.yml` (or the file specified with the `--config` option) is deployed at once.
 
 ### Plugins
 

--- a/docs/providers/cloudflare/cli-reference/deploy.md
+++ b/docs/providers/cloudflare/cli-reference/deploy.md
@@ -42,6 +42,7 @@ serverless deploy
 This is the simplest deployment usage possible. With this command, Serverless will deploy your service to Cloudflare.
  
 ## Options
+- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--verbose` or `-v`: Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f`: Invokes `deploy function` (see above). Convenience shortcut
 

--- a/docs/providers/cloudflare/guide/deploying.md
+++ b/docs/providers/cloudflare/guide/deploying.md
@@ -45,7 +45,9 @@ serverless deploy
 ```
 
 Use this method when you have updated your Function, Event or Resource configuration in `serverless.yml` and you want to deploy that change (or multiple changes at the same time) to your Cloudflare Worker. If you've made changes to any of your routes since last deploying, the Serverless Framework will update them on the server for you.
- 
+
+**Note:** You can specify a different configuration file name with the the `--config` option. 
+
 ### How It Works
 The Serverless Framework reads in `serverless.yml` and uses it to provision your Functions.
  

--- a/docs/providers/cloudflare/guide/intro.md
+++ b/docs/providers/cloudflare/guide/intro.md
@@ -32,7 +32,7 @@ A Function is a Cloudflare Worker. It's an independent unit of deployment, like 
 Anything that triggers a Cloudflare Worker Event to execute is regarded by the Framework as an **Event**. The only event that triggers a Cloudflare Worker is an HTTP request. Since the only event that can trigger a Worker is an HTTP request, declaring events is optional, and only used to declare specific endpoints that can be called by [`serverless invoke`](../cli-reference/invoke.md). This is useful for defining specific hooks into your application for testing.
  
 ### Services
-A **Service** is the Serverless Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application. It's where you define your Functions and the routes they will live on, all in one file entitled `serverless.yml`. Non-Enterprise Cloudflare accounts can only deploy one function (that can be deployed to multiple routes), while Enterprise Cloudflare accounts can deploy multiple functions at once: 
+A **Service** is the Serverless Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application. It's where you define your Functions and the routes they will live on, all in one file by default entitled `serverless.yml`. Non-Enterprise Cloudflare accounts can only deploy one function (that can be deployed to multiple routes), while Enterprise Cloudflare accounts can deploy multiple functions at once: 
 
 ```yml
 # serverless.yml
@@ -99,7 +99,7 @@ You’ll need to redefine your environmental variables after each time you close
 
 If you’re not an enterprise customer and you want to execute different code on multiple routes with only one funciton, we recommend writing code based off of our [conditional routing](https://developers.cloudflare.com/workers/recipes/conditional-routing/) template to check your route and execute different code accordingly. You can also write workers in separate files and compile it into one worker with [webpack](https://developers.cloudflare.com/workers/writing-workers/using-npm-modules/).
 
-When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` is deployed at once.
+When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` (or the file specified with the `--config` option) is deployed at once.
 
 ### Plugins
 

--- a/docs/providers/fn/cli-reference/deploy.md
+++ b/docs/providers/fn/cli-reference/deploy.md
@@ -23,6 +23,7 @@ serverless deploy
 This is the simplest deployment usage possible. With this command Serverless will deploy your service to the configured Fn server.
 
 ## Options
+- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut
 

--- a/docs/providers/fn/guide/deploying.md
+++ b/docs/providers/fn/guide/deploying.md
@@ -24,6 +24,8 @@ serverless deploy
 
 Use this method when you have updated your Function, Event or Resource configuration in `serverless.yml` and you want to deploy that change (or multiple changes at the same time) to your Fn cluster.
 
+**Note:** You can specify a different configuration file name with the the `--config` option. 
+
 ### How It Works
 
 The Serverless Framework translates all syntax in `serverless.yml` to [Fn](https://github.com/fnproject/fn) calls to provision your Functions.

--- a/docs/providers/fn/guide/intro.md
+++ b/docs/providers/fn/guide/intro.md
@@ -42,7 +42,7 @@ Anything that triggers an Fn Event to execute is regarded by the Framework as an
 
 ### Services
 
-A **Service** is the Serverless Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions and the Events that trigger them, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
+A **Service** is the Serverless Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions and the Events that trigger them, all in one file by default entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
 
 ```yml
 # serverless.yml
@@ -59,4 +59,4 @@ functions: # Your "Functions"
             path: /hello
 ```
 
-When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` is deployed at once.
+When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` (or the file specified with the `--config` option) is deployed at once.

--- a/docs/providers/google/cli-reference/deploy.md
+++ b/docs/providers/google/cli-reference/deploy.md
@@ -18,6 +18,9 @@ The `serverless deploy` command deploys your entire service via the Google Cloud
 serverless deploy
 ```
 
+## Options
+- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
+
 ## Artifacts
 
 After the `serverless deploy` command runs all created deployment artifacts are placed in the `.serverless` folder of the service.

--- a/docs/providers/google/guide/deploying.md
+++ b/docs/providers/google/guide/deploying.md
@@ -24,6 +24,8 @@ serverless deploy
 
 Use this method when you have updated your Function, Events or Resource configuration in `serverless.yml` and you want to deploy that change (or multiple changes at the same time) to the Google Cloud.
 
+**Note:** You can specify a different configuration file name with the the `--config` option. 
+
 ### How It Works
 
 The Serverless Framework translates all syntax in `serverless.yml` to a Google Deployment Manager configuration template.

--- a/docs/providers/google/guide/intro.md
+++ b/docs/providers/google/guide/intro.md
@@ -46,7 +46,7 @@ When you define an event for your Google Cloud Function in the Serverless Framew
 
 ### Services
 
-A **Service** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`). It looks like this:
+A **Service** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file by default entitled `serverless.yml` (or `serverless.json` or `serverless.js`). It looks like this:
 
 ```yml
 # serverless.yml
@@ -59,7 +59,7 @@ functions: # Your "Functions"
       - http: create
 ```
 
-When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` is deployed at once.
+When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` (or the file specified with the `--config` option) is deployed at once.
 
 ### Plugins
 

--- a/docs/providers/kubeless/cli-reference/deploy.md
+++ b/docs/providers/kubeless/cli-reference/deploy.md
@@ -23,6 +23,7 @@ serverless deploy
 This is the simplest deployment usage possible. With this command Serverless will deploy your service to the default Kubernetes cluster in your kubeconfig file.
 
 ## Options
+- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory.
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--package` or `-p` The path of a previously packaged deployment to get deployed (skips packaging step).

--- a/docs/providers/kubeless/guide/deploying.md
+++ b/docs/providers/kubeless/guide/deploying.md
@@ -24,6 +24,8 @@ serverless deploy -v
 
 Use this method when you have updated your Function, Event or Resource configuration in `serverless.yml` and you want to deploy that change (or multiple changes at the same time) to your Kubernetes cluster.
 
+**Note:** You can specify a different configuration file name with the the `--config` option. 
+
 ### How It Works
 
 The Serverless Framework translates all syntax in `serverless.yml` to [the Function object API](https://github.com/kubeless/kubeless/blob/master/pkg/spec/spec.go) calls to provision your Functions and Events.

--- a/docs/providers/kubeless/guide/intro.md
+++ b/docs/providers/kubeless/guide/intro.md
@@ -42,7 +42,7 @@ Anything that triggers an Kubeless Event to execute is regarded by the Framework
 
 ### Services
 
-A **Service** is the Serverless Framework's unit of organization (not to be confused with [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/).  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions and the Events that trigger them, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
+A **Service** is the Serverless Framework's unit of organization (not to be confused with [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/).  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions and the Events that trigger them, all in one file by default entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
 
 ```yml
 # serverless.yml
@@ -57,4 +57,4 @@ functions: # Your "Functions"
           path: /hello
 ```
 
-When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` is deployed at once.
+When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` (or the file specified with the `--config` option) is deployed at once.

--- a/docs/providers/openwhisk/cli-reference/deploy.md
+++ b/docs/providers/openwhisk/cli-reference/deploy.md
@@ -19,6 +19,7 @@ serverless deploy
 ```
 
 ## Options
+- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.

--- a/docs/providers/openwhisk/guide/deploying.md
+++ b/docs/providers/openwhisk/guide/deploying.md
@@ -24,6 +24,8 @@ serverless deploy
 
 Use this method when you have updated your Function, Event or Resource configuration in `serverless.yml` and you want to deploy that change (or multiple changes at the same time) to Apache OpenWhisk.
 
+**Note:** You can specify a different configuration file name with the the `--config` option. 
+
 ### How It Works
 
 The Serverless Framework translates all syntax in `serverless.yml` to [platform API](http://petstore.swagger.io/?url=https://raw.githubusercontent.com/openwhisk/openwhisk/master/core/controller/src/main/resources/whiskswagger.json) calls to provision your Actions, Triggers, Rules and APIs.

--- a/docs/providers/openwhisk/guide/intro.md
+++ b/docs/providers/openwhisk/guide/intro.md
@@ -47,7 +47,7 @@ When you define an event for your Apache OpenWhisk Action in the Serverless Fram
 
 ### Services
 
-A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
+A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file by default entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
 
 ```yml
 # serverless.yml
@@ -62,7 +62,7 @@ functions: # Your "Functions"
     events:
       - http: delete /users/delete
 ```
-When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` is deployed at once.
+When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` (or the file specified with the `--config` option) is deployed at once.
 
 ### Plugins
 

--- a/docs/providers/spotinst/cli-reference/deploy.md
+++ b/docs/providers/spotinst/cli-reference/deploy.md
@@ -19,5 +19,6 @@ serverless deploy -v
 ```
 
 ## Options
+- `--config` or `-c` Path to your conifguration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--package` or `-p` path to a pre-packaged directory and skip packaging step.
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.

--- a/docs/providers/spotinst/guide/intro.md
+++ b/docs/providers/spotinst/guide/intro.md
@@ -73,7 +73,7 @@ module.exports.main = function main (event, context, callback) {
 
 ### Services
 
-A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
+A **Service** is the Framework's unit of organization.  You can think of it as a project file, though you can have multiple services for a single application.  It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file by default entitled `serverless.yml` (or `serverless.json` or `serverless.js`).  It looks like this:
 
 ```yml
 
@@ -98,7 +98,7 @@ functions:
 #      key: value
 
 ```
-When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` is deployed at once.
+When you deploy with the Framework by running `serverless deploy`, everything in `serverless.yml` (or the file specified with the `--config` option) is deployed at once.
 
 ### Plugins
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Docs for PR #5589, which closes #4485

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I'm assuming that the new deploy option applies to all providers, so I just looked for the main existing documentation for `deploy` for each provider and added appropriate mentions of the new --config option for specifying a different config file name. I touched these docs for each provider:

Guide > Intro
Guide > Deploying
CLI Reference > Deploy

Most of the docs followed the same template, but I found three inconsistencies that I'm not sure how to resolve:

1. Google > CLI Reference > Deploy contained no "Options" section. I added this heading and included the --config option but I don't know which other options also apply to Google and should be included. There seems to be some variation across the different providers.
2. AWS > Guide > Deploying mentions a `--force` option that is not listed in CLI Reference > Deploy. It is a valid current option, and should it be added?
3. I noticed that the SpotInst provider has not Guide > Deploying doc. I'm not familiar with SpotInst so don't think I can write it at this time. Probably that can be out of scope for this PR.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] Review documentation changes
- [ ] Clarify full set of CLI deploy options for Google provider
- [ ] Clarify whether `--force` should be listed in AWS > CLI Reference > Deploy
- [ ] Add a Guide > Deploying doc for SpotInst? 

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
